### PR TITLE
add sapling support for encoding and signing transactions

### DIFF
--- a/msgtx.go
+++ b/msgtx.go
@@ -35,15 +35,16 @@ func (msg *MsgTx) TxHash() chainhash.Hash {
 // This is part of the Message interface implementation.
 // See Serialize for encoding transactions to be stored to disk, such as in a
 // database, as opposed to encoding transactions for the wire.
+// msg.Version must be 3 or 4 and may or may not include the overwintered flag
 func (msg *MsgTx) ZecEncode(w io.Writer, pver uint32, enc wire.MessageEncoding) error {
 	err := binarySerializer.PutUint32(w, littleEndian, uint32(msg.Version)|(1<<31))
 	if err != nil {
 		return err
 	}
 
-	var versionGroupID uint32 = 0x3C48270
-	if msg.Version == 4 {
-		versionGroupID = 0x892F2085
+	var versionGroupID uint32 = versionGroupIDOverwinter
+	if versionEqual(uint32(msg.Version), nVersionSapling) {
+		versionGroupID = versionGroupIDSapling
 	}
 	err = binarySerializer.PutUint32(w, littleEndian, versionGroupID)
 	if err != nil {

--- a/msgtx.go
+++ b/msgtx.go
@@ -26,6 +26,7 @@ var witessMarkerBytes = []byte{0x00, 0x01}
 
 // TxHash generates the Hash for the transaction.
 func (msg *MsgTx) TxHash() chainhash.Hash {
+
 	var buf bytes.Buffer
 	msg.ZecEncode(&buf, 0, wire.BaseEncoding)
 	return chainhash.DoubleHashH(buf.Bytes())
@@ -115,7 +116,7 @@ func (msg *MsgTx) ZecEncode(w io.Writer, pver uint32, enc wire.MessageEncoding) 
 		return err
 	}
 
-	if msg.Version >= 4 {
+	if versionEqual(uint32(msg.Version), 4) {
 		// valueBalance
 		if err = binarySerializer.PutUint64(w, littleEndian, 0); err != nil {
 			return err

--- a/sign.go
+++ b/sign.go
@@ -16,20 +16,28 @@ import (
 )
 
 const (
-	sigHashMask           = 0x1f
-	versionGroupID uint32 = 0x3C48270
-	nVersion       uint32 = 3 | (1 << 31)
-	blake2BSigHash        = "ZcashSigHash"
+	sigHashMask                     = 0x1f
+	versionGroupIDOverwinter uint32 = 0x3C48270
+	nVersionOverwinter       uint32 = 3 | (1 << 31)
+	versionGroupIDSapling    uint32 = 0x3C48270
+	nVersionSapling          uint32 = 4 | (1 << 31)
+	blake2BSigHash                  = "ZcashSigHash"
 )
+
+func versionEqual(v1, v2 uint32) bool {
+	return v1&0x7fffffff == v2&0x7fffffff
+}
 
 type upgradeParam struct {
 	activationHeight uint32
 	branchID         []byte
 }
 
+// https://github.com/zcash/zcash/blob/89f5ee5dec3fdfd70202baeaf74f09fa32bfb1a8/src/chainparams.cpp#L99
 var upgradeParams = []upgradeParam{
 	{0, []byte{0x00, 0x00, 0x00, 0x00}},
 	{207500, []byte{0x19, 0x1B, 0xA8, 0x5B}},
+	{419200, []byte{0xBB, 0x09, 0xB8, 0x76}},
 }
 
 // RawTxInSignature returns the serialized ECDSA signature for the input idx of
@@ -158,8 +166,13 @@ func blake2bSignatureHash(
 	// << GetHeader
 	// First write out, then encode the transaction's nVersion number. Zcash current nVersion = 3
 	var bVersion [4]byte
-	binary.LittleEndian.PutUint32(bVersion[:], nVersion)
+	binary.LittleEndian.PutUint32(bVersion[:], uint32(tx.Version)|(1<<31))
 	sigHash.Write(bVersion[:])
+
+	var versionGroupID uint32 = versionGroupIDOverwinter
+	if versionEqual(uint32(tx.Version), nVersionSapling) {
+		versionGroupID = versionGroupIDSapling
+	}
 
 	// << nVersionGroupId
 	// Version group ID
@@ -220,6 +233,16 @@ func blake2bSignatureHash(
 	// << hashJoinSplits
 	sigHash.Write(zeroHash[:])
 
+	// << hashShieldedSpends
+	if versionEqual(uint32(tx.Version), nVersionSapling) {
+		sigHash.Write(zeroHash[:])
+	}
+
+	// << hashShieldedOutputs
+	if versionEqual(uint32(tx.Version), nVersionSapling) {
+		sigHash.Write(zeroHash[:])
+	}
+
 	// << nLockTime
 	var lockTime [4]byte
 	binary.LittleEndian.PutUint32(lockTime[:], tx.LockTime)
@@ -229,6 +252,13 @@ func blake2bSignatureHash(
 	var expiryTime [4]byte
 	binary.LittleEndian.PutUint32(expiryTime[:], tx.ExpiryHeight)
 	sigHash.Write(expiryTime[:])
+
+	// << valueBalance
+	if versionEqual(uint32(tx.Version), nVersionSapling) {
+		var valueBalance [4]byte
+		binary.LittleEndian.PutUint32(nVersion[:], 0)
+		sigHash.Write(valueBalance[:])
+	}
 
 	// << nHashType
 	var bHashType [4]byte

--- a/sign.go
+++ b/sign.go
@@ -19,7 +19,7 @@ const (
 	sigHashMask                     = 0x1f
 	versionGroupIDOverwinter uint32 = 0x3C48270
 	nVersionOverwinter       uint32 = 3 | (1 << 31)
-	versionGroupIDSapling    uint32 = 0x3C48270
+	versionGroupIDSapling    uint32 = 0x892f2085
 	nVersionSapling          uint32 = 4 | (1 << 31)
 	blake2BSigHash                  = "ZcashSigHash"
 )

--- a/sign.go
+++ b/sign.go
@@ -255,8 +255,8 @@ func blake2bSignatureHash(
 
 	// << valueBalance
 	if versionEqual(uint32(tx.Version), nVersionSapling) {
-		var valueBalance [4]byte
-		binary.LittleEndian.PutUint32(nVersion[:], 0)
+		var valueBalance [8]byte
+		binary.LittleEndian.PutUint64(valueBalance[:], 0)
 		sigHash.Write(valueBalance[:])
 	}
 

--- a/zecaddr.go
+++ b/zecaddr.go
@@ -43,6 +43,10 @@ type ZecAddressPubKeyHash struct {
 	prefix string
 }
 
+func NewAddressPubKeyHash(hash [ripemd160.Size]byte, prefix string) *ZecAddressPubKeyHash {
+	return &ZecAddressPubKeyHash{hash, prefix}
+}
+
 // Encode pubHash to zec address
 func Encode(pkHash []byte, net *chaincfg.Params) (_ string, err error) {
 	if _, ok := NetList[net.Name]; !ok {


### PR DESCRIPTION
I had a need to encode zcash transactions for sapling and I started making modifications to make this library work on sapling. This was the smallest possible change to encode sapling transactions and doesn't include the signing logic. I just wanted to open this PR for visibility and to get the conversation started. I'll be working on the signing soon as well, so any tips would be appreciated.

I also have some code for decoding transactions which I've kept outside this repo, but it could potentially be included here in the future, but that would be outside the scope of this PR.