### PR TITLE
use a more standard blake2b library

### DIFF
--- a/hash.go
+++ b/hash.go
@@ -2,15 +2,15 @@ package zecutil
 
 import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
-	"github.com/codahale/blake2"
+	"github.com/dchest/blake2b"
 )
 
 // blake2bHash zcash hash func
 func blake2bHash(data, key []byte) (h chainhash.Hash, err error) {
-	bHash := blake2.New(&blake2.Config{
-		Size:     32,
-		Personal: key,
-	})
+	bHash, err := blake2b.New(&blake2b.Config{Size: 32, Person: key})
+	if err != nil {
+		return h, err
+	}
 
 	if _, err = bHash.Write(data); err != nil {
 		return h, err


### PR DESCRIPTION
The blake2 library doesn't have a pure go implementation and works only with CGO. This library is better and more popular / standard.